### PR TITLE
CodeOwners Datei für die Ereignisse-API

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,9 @@
+# Baufismart Ereignisse-API Code Owners
+#
+# Siehe auch:
+# - https://help.github.com/articles/about-codeowners/
+#
+# Bitte die Sortierung dieser Datei beibehalten. Die zuletzt zutreffende Regel
+# hat Vorrang.
+
+* @europace/baufi-annahme_pooler


### PR DESCRIPTION
 Ich möchte das verantwortliche Team am Repo sichtbar machen, da die Implementierung doch sehr weit weg ist und wir als Verantwortliche bei Veränderungen involviert sein wollen.

 Die CodeOwners verstehe ich als Ansprechpartner für Anpassungen im API-Auftritt.
 
Dieser Vorschlag soll genutzt werden, um gemeinsam mit den bisherigen Verantwortlichen zu einer ersten Version zu kommen.

AN-194