### PR TITLE
[AN-1437] Fehlenden ENUM-Wert für eigene Vorgangsnummer ergänzt

### DIFF
--- a/swagger.yaml
+++ b/swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.0
 info:
   description: API für Ereignisse in BaufiSmart-Vorgängen.
-  version: 2.0.0
+  version: 2.1.0
   title: Ereignisse API
   contact:
     name: Europace AG
@@ -35,7 +35,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Ereignis'
-              examples: {}
+              examples: { }
         '401':
           description: |-
             Unauthorized
@@ -352,6 +352,7 @@ components:
             - KOMMUNIKATION
             - HINWEIS
             - EXPORT
+            - EIGENE_VORGANGSNUMMER
         zeitpunkt:
           type: string
           format: date-time


### PR DESCRIPTION
Bisher wird das Ereignis EIGENE_VORGANGSNUMMER ohne Ereignistyp ausgeliefert, das macht das Verarbeiten der Ereignisse über die API durch clients schwieriger.

Changes:
- neuer Wert für TypEnum am Ereignis
- Erhöhung der Version auf 2.1.0
- kein breaking change

[Zendeskticket](https://europace2.zendesk.com/agent/tickets/210642)

Closes [AN-1437]

[AN-1437]: https://europace.atlassian.net/browse/AN-1437